### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,13 @@ Features
   them.
 * Load an object from a module using a middleware classes like import path.
 * Unittested (see http://ci.django-cms.org/job/django-load/)
-* Documented (see http://django-load.readthedocs.org)
+* Documented (see https://django-load.readthedocs.io)
 
 ********
 Examples
 ********
 
-For full API documentation, please refer to http://django-load.readthedocs.org.
+For full API documentation, please refer to https://django-load.readthedocs.io.
 
 Let's assume your app wants to load all ``plugins.py`` files from the installed
 apps, to allow those apps to extend your application. You can achieve this like


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
